### PR TITLE
[R] usb: 1.0-basic: Add vintf_fragment

### DIFF
--- a/usb/1.0-basic/Android.bp
+++ b/usb/1.0-basic/Android.bp
@@ -17,6 +17,7 @@ cc_binary {
     name: "android.hardware.usb@1.0-service.basic",
     relative_install_path: "hw",
     init_rc: ["android.hardware.usb@1.0-service.basic.rc"],
+    vintf_fragments: ["manifest_android.hardware.usb@1.0.xml"],
     srcs: ["service.cpp", "Usb.cpp"],
     shared_libs: [
         "libbase",

--- a/usb/1.0-basic/manifest_android.hardware.usb@1.0.xml
+++ b/usb/1.0-basic/manifest_android.hardware.usb@1.0.xml
@@ -1,0 +1,11 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>android.hardware.usb</name>
+        <transport>hwbinder</transport>
+        <version>1.0</version>
+        <interface>
+            <name>IUsb</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+</manifest>


### PR DESCRIPTION
The default AOSP HAL in hardware/interfaces does the same.

This necessitates taking out the `IUsb` section from the device-sony-common `manifest.xml`.

Note: This change is incompatible with Android 9 and the `android-10_legacy` branches.