### PR TITLE
[R/Q] android.bp: Remove hidltransport and hwbinder from shared libs

### DIFF
--- a/usb/1.0-basic/Android.bp
+++ b/usb/1.0-basic/Android.bp
@@ -23,8 +23,6 @@ cc_binary {
         "libbase",
         "libcutils",
         "libhidlbase",
-        "libhidltransport",
-        "libhwbinder",
         "libutils",
         "libhardware",
         "android.hardware.usb@1.0",


### PR DESCRIPTION
In Android R libhwbinder and libhidltransport are no longer available to use.
Thus let's remove the libraries.